### PR TITLE
fix error on first run

### DIFF
--- a/desktop-creator.py
+++ b/desktop-creator.py
@@ -15,6 +15,9 @@ url = sys.argv[1]
 
 name = sys.argv[2]
 
+# If this is the first run we need to create the images directory
+os.system("mkdir -p images/")
+
 # Make a request to the webpage to find the icon
 favicon_url = pyfav_utils.get_favicon_url(url)
 


### PR DESCRIPTION
If the images/ directory doesn't exist (eg on first run) the script will throw an error. This addition creates the directory if it doesn't already exist, avoiding the error.